### PR TITLE
Add support for rclcpp::shutdown and deletion of tflistener resources

### DIFF
--- a/rclcppdotnet/RclCppDotnet.cs
+++ b/rclcppdotnet/RclCppDotnet.cs
@@ -17,6 +17,10 @@ namespace ROS2 {
         internal delegate void NativeRclcppInitType();
         internal static NativeRclcppInitType native_rclcpp_init = null;
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void NativeRclcppShutdownType();
+        internal static NativeRclcppShutdownType native_rclcpp_shutdown = null;
+
         static RclCppDotnetDelegates() {
             dllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
             IntPtr pDll = dllLoadUtils.LoadLibrary("rclcppdotnet");
@@ -24,6 +28,10 @@ namespace ROS2 {
             IntPtr native_rclcpp_init_ptr = dllLoadUtils.GetProcAddress(pDll, "native_rclcpp_init");
             RclCppDotnetDelegates.native_rclcpp_init = (NativeRclcppInitType)Marshal.GetDelegateForFunctionPointer(
                 native_rclcpp_init_ptr, typeof(NativeRclcppInitType));
+
+            IntPtr native_rclcpp_shutdown_ptr = dllLoadUtils.GetProcAddress(pDll, "native_rclcpp_shutdown");
+            RclCppDotnetDelegates.native_rclcpp_shutdown = (NativeRclcppShutdownType)Marshal.GetDelegateForFunctionPointer(
+                native_rclcpp_shutdown_ptr, typeof(NativeRclcppShutdownType));
         }
     }
 
@@ -39,6 +47,18 @@ namespace ROS2 {
                 {
                     RclCppDotnetDelegates.native_rclcpp_init();
                     initialized = true;
+                }
+            }
+        }
+
+        public static void Shutdown()
+        {
+            lock (syncLock)
+            {
+                if (initialized)
+                {
+                    RclCppDotnetDelegates.native_rclcpp_shutdown();
+                    initialized = false;
                 }
             }
         }

--- a/rclcppdotnet/rclcppdotnet.cpp
+++ b/rclcppdotnet/rclcppdotnet.cpp
@@ -5,3 +5,10 @@
 void native_rclcpp_init() {
 	rclcpp::init(0, nullptr);  // no args
 }
+
+void native_rclcpp_shutdown() {
+	if (rclcpp::ok()) {
+		rclcpp::shutdown();
+	}
+}
+

--- a/rclcppdotnet/rclcppdotnet.h
+++ b/rclcppdotnet/rclcppdotnet.h
@@ -8,6 +8,9 @@ extern "C" {
 	__declspec(dllexport)
 	void __cdecl native_rclcpp_init();
 
+    __declspec(dllexport)
+	void __cdecl native_rclcpp_shutdown();
+
 #ifdef __cplusplus
 }
 #endif

--- a/rclcppdotnet/transform_listener.cpp
+++ b/rclcppdotnet/transform_listener.cpp
@@ -14,8 +14,18 @@ void* native_construct_buffer() {
 	return new tf2_ros::Buffer(clock);
 }
 
+void native_delete_buffer(void* buf) {
+	auto casted = (tf2_ros::Buffer*)buf;
+	delete casted;
+}
+
 void* native_construct_listener(void* buf) {
 	return new tf2_ros::TransformListener(*((tf2_ros::Buffer*)buf));
+}
+
+void native_delete_listener(void* listener) {
+	auto casted = (tf2_ros::TransformListener*)listener;
+	delete listener;
 }
 
 void* native_construct_time(int sec, int nano) {
@@ -24,10 +34,15 @@ void* native_construct_time(int sec, int nano) {
 
 void* native_lookup_transform(void* buf,
 	char* from, char* to, void* t) {
-	auto outputVar = new geometry_msgs::msg::TransformStamped(
-		((tf2_ros::Buffer*)buf)->lookupTransform((char*)from, (char*)to, *((rclcpp::Time*)t))
-	);
-	return outputVar;
+	try {
+		auto outputVar = new geometry_msgs::msg::TransformStamped(
+			((tf2_ros::Buffer*)buf)->lookupTransform((char*)from, (char*)to, *((rclcpp::Time*)t))
+		);
+		return outputVar;
+	}
+	catch (tf2::TransformException &ex) {
+		return nullptr;
+	}
 }
 
 bool native_retrieve_translation(void* tf, TfVector3Ptr vec) {

--- a/rclcppdotnet/transform_listener.h
+++ b/rclcppdotnet/transform_listener.h
@@ -23,7 +23,13 @@ extern "C" {
 	void* __cdecl native_construct_buffer();
 
 	__declspec(dllexport)
+	void __cdecl native_delete_buffer(void* buf);
+
+	__declspec(dllexport)
 	void* __cdecl native_construct_listener(void* buf);
+
+	__declspec(dllexport)
+	void __cdecl native_delete_listener(void* listener);
 
 	__declspec(dllexport)
 	void* __cdecl native_construct_time(int sec, int nano);


### PR DESCRIPTION
Duplicate node issue persists in both ROS1 and ROS2; this only fixes the rclcpp memory leak/crash